### PR TITLE
EDX-1356: ensured V62 "OTHERCOURSEINVALID" error isn't triggered when…

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/constants/v1/OtherCoursesCodes.java
+++ b/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/constants/v1/OtherCoursesCodes.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 public enum OtherCoursesCodes {
+    ZERO("0"),
     ONE("1"),
     TWO("2"),
     THREE("3"),


### PR DESCRIPTION
… the "OTHER_COURSES" field is reported as "0".