### PR TITLE
Bug fix for edx-1689

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/rules/validationrulesimpl/DuplicatePenRule.java
+++ b/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/rules/validationrulesimpl/DuplicatePenRule.java
@@ -39,9 +39,11 @@ public class DuplicatePenRule implements ValidationBaseRule {
     @Override
     public List<SdcSchoolCollectionStudentValidationIssue> executeValidation(SdcStudentSagaData sdcStudentSagaData) {
         final List<SdcSchoolCollectionStudentValidationIssue> errors = new ArrayList<>();
-        Long penCount = validationRulesService.getDuplicatePenCount(sdcStudentSagaData.getSdcSchoolCollectionStudent().getSdcSchoolCollectionID(), sdcStudentSagaData.getSdcSchoolCollectionStudent().getStudentPen());
-        if(StringUtils.isEmpty(sdcStudentSagaData.getSdcSchoolCollectionStudent().getStudentPen()) || penCount > 1) {
-            errors.add(createValidationIssue(SdcSchoolCollectionStudentValidationIssueSeverityCode.ERROR, SdcSchoolCollectionStudentValidationFieldCode.STUDENT_PEN, SdcSchoolCollectionStudentValidationIssueTypeCode.STUDENT_PEN_DUPLICATE));
+        if(StringUtils.isNotEmpty(sdcStudentSagaData.getSdcSchoolCollectionStudent().getStudentPen())) {
+            Long penCount = validationRulesService.getDuplicatePenCount(sdcStudentSagaData.getSdcSchoolCollectionStudent().getSdcSchoolCollectionID(), sdcStudentSagaData.getSdcSchoolCollectionStudent().getStudentPen());
+            if (penCount > 1) {
+                errors.add(createValidationIssue(SdcSchoolCollectionStudentValidationIssueSeverityCode.ERROR, SdcSchoolCollectionStudentValidationFieldCode.STUDENT_PEN, SdcSchoolCollectionStudentValidationIssueTypeCode.STUDENT_PEN_DUPLICATE));
+            }
         }
         return errors;
     }

--- a/api/src/test/java/ca/bc/gov/educ/studentdatacollection/api/rules/RulesProcessorTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/studentdatacollection/api/rules/RulesProcessorTest.java
@@ -122,7 +122,26 @@ class RulesProcessorTest extends BaseStudentDataCollectionAPITest {
     }
 
     @Test
-    void testSchoolRule() {
+    void testStandardSchoolWithBlankPen() {
+        var collection = collectionRepository.save(createMockCollectionEntity());
+        var sdcSchoolCollectionEntity = sdcSchoolCollectionRepository.save(createMockSdcSchoolCollectionEntity(collection, null, null));
+        val entity = this.createMockSchoolStudentEntity(sdcSchoolCollectionEntity);
+        entity.setEnrolledGradeCode("08");
+        val school = createMockSchool();
+        school.setFacilityTypeCode("STANDARD");
+
+        val validationError = rulesProcessor.processRules(createMockStudentSagaData(SdcSchoolCollectionStudentMapper.mapper.toSdcSchoolStudent(entity), school));
+        assertThat(validationError.size()).isZero();
+
+        entity.setStudentPen(null);
+        val sagaData = createMockStudentSagaData(SdcSchoolCollectionStudentMapper.mapper.toSdcSchoolStudent(entity), school);
+        sagaData.setCollectionTypeCode("JULY");
+        val validationErrorBlank = rulesProcessor.processRules(sagaData);
+        assertThat(validationErrorBlank.size()).isZero();
+    }
+
+    @Test
+    void testSummerSchoolWithBlankPen(){
         var collection = collectionRepository.save(createMockCollectionEntity());
         var sdcSchoolCollectionEntity = sdcSchoolCollectionRepository.save(createMockSdcSchoolCollectionEntity(collection, null, null));
         val entity = this.createMockSchoolStudentEntity(sdcSchoolCollectionEntity);
@@ -139,6 +158,7 @@ class RulesProcessorTest extends BaseStudentDataCollectionAPITest {
         val validationErrorBlank = rulesProcessor.processRules(sagaData);
         assertThat(validationErrorBlank.size()).isNotZero();
         assertThat(validationErrorBlank.get(0).getValidationIssueFieldCode()).isEqualTo("STUDENT_PEN");
+        assertThat(validationErrorBlank.get(0).getValidationIssueCode()).isEqualTo("STUDENTPENBLANK");
     }
 
     @Test
@@ -327,7 +347,7 @@ class RulesProcessorTest extends BaseStudentDataCollectionAPITest {
     }
 
     @Test
-    void testPenRule() {
+    void testDuplicatePenRule() {
         var collection = collectionRepository.save(createMockCollectionEntity());
         var sdcSchoolCollectionEntity = sdcSchoolCollectionRepository.save(createMockSdcSchoolCollectionEntity(collection, null, null));
         val entity = createMockSchoolStudentEntity(sdcSchoolCollectionEntity);
@@ -363,8 +383,7 @@ class RulesProcessorTest extends BaseStudentDataCollectionAPITest {
 
         entity.setStudentPen(null);
         val validationError = rulesProcessor.processRules(createMockStudentSagaData(SdcSchoolCollectionStudentMapper.mapper.toSdcSchoolStudent(entity), createMockSchool()));
-        assertThat(validationError.size()).isNotZero();
-        assertThat(validationError.get(0).getValidationIssueCode()).isEqualTo("STUDENTPENDUPLICATE");
+        assertThat(validationError.size()).isZero();
 
         entity.setStudentPen("2345");
         val validationDigitError = rulesProcessor.processRules(createMockStudentSagaData(SdcSchoolCollectionStudentMapper.mapper.toSdcSchoolStudent(entity), createMockSchool()));


### PR DESCRIPTION
This bug fix is for making sure if there's no pen reported and the school type is Standard, then the code should not throw duplicate error. Instead no error is thrown for a standard school with no PEN