### PR TITLE
A couple more ELL headcount table fixes

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/helpers/EllHeadcountHelper.java
+++ b/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/helpers/EllHeadcountHelper.java
@@ -141,17 +141,16 @@ public class EllHeadcountHelper extends HeadcountHelper<EllHeadcountResult> {
   }
 
   private Map<String, String> getRowTitles() {
-    Map<String, String> rowTitles = Map.of(
-        SCHOOL_AGED_TOTALS, TOTAL_GRADE_TITLE,
-        SCHOOL_AGED_1_5, ONE_TO_FIVE_TITLE,
-        SCHOOL_AGED_6_PLUS, SIX_PLUS_TITLE,
-        ADULT_TOTALS, ADULT_TITLE,
-        ADULT_1_5, ONE_TO_FIVE_TITLE,
-        ADULT_6_PLUS, SIX_PLUS_TITLE,
-        TOTAL_ELL_STUDENTS, ALL_STUDENTS_TITLE,
-        ALL_1_5, ONE_TO_FIVE_TITLE,
-        ALL_6_PLUS, SIX_PLUS_TITLE);
-
+    Map<String, String> rowTitles = new LinkedHashMap<>();
+    rowTitles.put(SCHOOL_AGED_TOTALS, TOTAL_GRADE_TITLE);
+    rowTitles.put(SCHOOL_AGED_1_5, ONE_TO_FIVE_TITLE);
+    rowTitles.put(SCHOOL_AGED_6_PLUS, SIX_PLUS_TITLE);
+    rowTitles.put(ADULT_TOTALS, ADULT_TITLE);
+    rowTitles.put(ADULT_1_5, ONE_TO_FIVE_TITLE);
+    rowTitles.put(ADULT_6_PLUS, SIX_PLUS_TITLE);
+    rowTitles.put(TOTAL_ELL_STUDENTS, ALL_STUDENTS_TITLE);
+    rowTitles.put(ALL_1_5, ONE_TO_FIVE_TITLE);
+    rowTitles.put(ALL_6_PLUS, SIX_PLUS_TITLE);
     return rowTitles;
   }
 }

--- a/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/helpers/EllHeadcountHelper.java
+++ b/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/helpers/EllHeadcountHelper.java
@@ -37,9 +37,6 @@ public class EllHeadcountHelper extends HeadcountHelper<EllHeadcountResult> {
   private static final String ONE_TO_FIVE_TITLE = "1-5 Years";
   private static final String SIX_PLUS_TITLE = "6+ Years";
 
-  // Total column title in table data
-  private static final String TOTAL_GRADE_TITLE = "Total";
-
   // Hash keys
   private static final String SCHOOL_AGED_1_5 = "schoolAgedOneThroughFive";
   private static final String SCHOOL_AGED_6_PLUS = "schoolAgedSixPlus";
@@ -142,7 +139,7 @@ public class EllHeadcountHelper extends HeadcountHelper<EllHeadcountResult> {
 
   private Map<String, String> getRowTitles() {
     Map<String, String> rowTitles = new LinkedHashMap<>();
-    rowTitles.put(SCHOOL_AGED_TOTALS, TOTAL_GRADE_TITLE);
+    rowTitles.put(SCHOOL_AGED_TOTALS, SCHOOL_AGED_TITLE);
     rowTitles.put(SCHOOL_AGED_1_5, ONE_TO_FIVE_TITLE);
     rowTitles.put(SCHOOL_AGED_6_PLUS, SIX_PLUS_TITLE);
     rowTitles.put(ADULT_TOTALS, ADULT_TITLE);


### PR DESCRIPTION
It turns out that the Map.of() method does not maintain any ordinal position of its arguments.  Makes for a bad table in the front end.