### PR TITLE
SCH | SLD (1701) |V79 & V25 funding warnings disappear when a user selects a Funding Code as 14 (Out-of-Province/International Student).

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/rules/validationrules/impl/OutOfProvinceSpecialEducRule.java
+++ b/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/rules/validationrules/impl/OutOfProvinceSpecialEducRule.java
@@ -26,7 +26,7 @@ import java.util.List;
  */
 @Component
 @Slf4j
-@Order(670)
+@Order(680)
 public class OutOfProvinceSpecialEducRule implements ValidationBaseRule {
 
     @Override

--- a/api/src/test/java/ca/bc/gov/educ/studentdatacollection/api/rules/RulesProcessorTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/studentdatacollection/api/rules/RulesProcessorTest.java
@@ -448,6 +448,7 @@ class RulesProcessorTest extends BaseStudentDataCollectionAPITest {
         val entity = this.createMockSchoolStudentEntity(sdcSchoolCollectionEntity);
         entity.setEnrolledGradeCode("HS");
         entity.setEnrolledProgramCodes("05");
+        entity.setBandCode(null);
 
         val validationError = rulesProcessor.processRules(createMockStudentRuleData(entity, createMockSchool()));
         assertThat(validationError.size()).isNotZero();
@@ -465,6 +466,14 @@ class RulesProcessorTest extends BaseStudentDataCollectionAPITest {
         assertThat(validationErrorSped.size()).isNotZero();
         val error1 = validationErrorSped.stream().anyMatch(val -> val.getValidationIssueCode().equals("PROGRAMCODEHSSPED"));
         assertThat(error1).isTrue();
+
+        entity.setEnrolledProgramCodes(null);
+        entity.setSpecialEducationCategoryCode("A");
+        entity.setSchoolFundingCode("14");
+        val validationErrorFunding = rulesProcessor.processRules(createMockStudentRuleData(entity, createMockSchool()));
+        assertThat(validationErrorFunding.size()).isNotZero();
+        val fundingError = validationErrorFunding.stream().anyMatch(val -> val.getValidationIssueCode().equals("PROGRAMCODEHSSPED"));
+        assertThat(fundingError).isTrue();
     }
 
     @Test


### PR DESCRIPTION
please reference comment in https://eccbc.atlassian.net/jira/software/c/projects/EDX/boards/17?selectedIssue=EDX-2374