### PR TITLE
show prev band data when compare (ie x where x > 0 -> 0)

### DIFF
--- a/api/src/test/java/ca/bc/gov/educ/studentdatacollection/api/service/v1/SdcSchoolCollectionStudentHeadcountServiceTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/studentdatacollection/api/service/v1/SdcSchoolCollectionStudentHeadcountServiceTest.java
@@ -163,7 +163,7 @@ class SdcSchoolCollectionStudentHeadcountServiceTest extends BaseStudentDataColl
 
         var resultsTableWithCompare = service.getBandResidenceHeadcounts(firstSchoolCollection, true);
         var allStudentsWithCompareRow = resultsTableWithCompare.getHeadcountResultsTable().getRows().stream().filter(val -> val.get("title").getCurrentValue().equals("All Bands & Students")).findAny();
-        assertEquals(3, resultsTableWithCompare.getHeadcountResultsTable().getRows().size());
+        assertEquals(4, resultsTableWithCompare.getHeadcountResultsTable().getRows().size());
         assertEquals("2.46", allStudentsWithCompareRow.get().get("FTE").getCurrentValue());
         assertEquals("2", allStudentsWithCompareRow.get().get("Headcount").getCurrentValue());
         assertEquals("1.14", allStudentsWithCompareRow.get().get("FTE").getComparisonValue());


### PR DESCRIPTION
this is to deal with the case when prev collection had students with a band code that no longer is in the current collection. Previously compare would not show x -> 0. Now it does. 