### PR TITLE
Changes to allow signature with roles "Superintendent" or "Secretary …

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/endpoint/v1/SdcDistrictCollectionEndpoint.java
+++ b/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/endpoint/v1/SdcDistrictCollectionEndpoint.java
@@ -102,7 +102,7 @@ public interface SdcDistrictCollectionEndpoint {
   List<SdcSchoolCollection> getSchoolCollectionsInDistrictCollection(@PathVariable("sdcDistrictCollectionID") UUID sdcDistrictCollectionID);
 
   @PostMapping("/{sdcDistrictCollectionID}/sign-off")
-  @PreAuthorize("hasAuthority('SCOPE_WRITE_SDC_DISTRICT_COLLECTION')")
+  @PreAuthorize("hasAuthority('SCOPE_WRITE_SDC_DISTRICT_COLLECTION') or hasAnyRole('SUPERINT','SECR_TRES')")
   @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "OK"), @ApiResponse(responseCode = "400", description = "BAD REQUEST"), @ApiResponse(responseCode = "404", description = "NOT FOUND")})
   @Transactional
   @Schema(name = "SdcDistrictCollectionSubmissionSignature", implementation = SdcDistrictCollectionSubmissionSignature.class)


### PR DESCRIPTION
Description: 
Changes to allow signature with roles "Superintendent" or "Secretary Treasurer" only

Unit Testing:
1. Verify the data is read only for  "Superintendent" or "Secretary Treasurer" only
2. Ability to sign the collection
3. Swap to edit district collection and verify signature to pass through.