### PR TITLE
v99 order and clarifying rule wording

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/calculator/FteCalculatorUtils.java
+++ b/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/calculator/FteCalculatorUtils.java
@@ -272,14 +272,9 @@ public class FteCalculatorUtils {
     }
 
     public boolean reportedInOtherDistrictsInPreviousCollectionThisSchoolYearInGrade8Or9WithNonZeroFte(StudentRuleData studentRuleData) {
-        List<SdcSchoolCollectionStudentEntity> historicalCollections = sdcSchoolCollectionStudentRepository.findStudentInCurrentFiscalInOtherDistricts(UUID.fromString(studentRuleData.getSchool().getDistrictId()), studentRuleData.getSdcSchoolCollectionStudentEntity().getAssignedStudentId(), "3");
-
-        for (SdcSchoolCollectionStudentEntity studentEntity : historicalCollections) {
-            if (SchoolGradeCodes.getGrades8and9().contains(studentEntity.getEnrolledGradeCode()) && !studentEntity.getFte().equals(BigDecimal.ZERO)) {
-                return true;
-            }
-        }
-        return false;
+        String noOfCollectionsForLookup = "3";
+        List<SdcSchoolCollectionStudentEntity> entity = sdcSchoolCollectionStudentRepository.findStudentInCurrentFiscalInOtherDistrictsNotInGrade8Or9WithNonZeroFte(UUID.fromString(studentRuleData.getSchool().getDistrictId()), studentRuleData.getSdcSchoolCollectionStudentEntity().getAssignedStudentId(), noOfCollectionsForLookup);
+        return !entity.isEmpty();
     }
 
     private LocalDate getFiscalDateFromCurrentSnapshot(LocalDate currentSnapshotDate){

--- a/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/repository/v1/SdcSchoolCollectionStudentRepository.java
+++ b/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/repository/v1/SdcSchoolCollectionStudentRepository.java
@@ -1064,7 +1064,7 @@ public interface SdcSchoolCollectionStudentRepository extends JpaRepository<SdcS
             AND C.collectionID IN
                   (SELECT CE.collectionID FROM CollectionEntity CE WHERE CE.collectionStatusCode = 'COMPLETED' ORDER BY CE.snapshotDate DESC LIMIT :noOfCollections)
             """)
-  List<SdcSchoolCollectionStudentEntity> findStudentInCurrentFiscalInOtherDistricts(UUID districtID, UUID assignedStudentID, String noOfCollections);
+  List<SdcSchoolCollectionStudentEntity> findStudentInCurrentFiscalInOtherDistrictsNotInGrade8Or9WithNonZeroFte(UUID districtID, UUID assignedStudentID, String noOfCollections);
 
   List<SdcSchoolCollectionStudentEntity> findAllBySdcSchoolCollection_CollectionEntity_CollectionIDAndEnrolledGradeCodeIn(UUID collectionID, List<String> enrolledGradeCode);
 

--- a/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/rules/validationrules/impl/SummerStudentOnlineLearningRule.java
+++ b/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/rules/validationrules/impl/SummerStudentOnlineLearningRule.java
@@ -38,7 +38,7 @@ import java.util.Optional;
  */
 @Component
 @Slf4j
-@Order(924)
+@Order(926)
 public class SummerStudentOnlineLearningRule implements ValidationBaseRule {
     private final ValidationRulesService validationRulesService;
     private final RestUtils restUtils;

--- a/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/rules/validationrules/impl/SummerStudentReportedInOtherDistrictRule.java
+++ b/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/rules/validationrules/impl/SummerStudentReportedInOtherDistrictRule.java
@@ -20,13 +20,13 @@ import java.util.List;
 /**
  *  | ID  | Severity | Rule                                                          | Dependent On |
  *  |-----|----------|-------------------------------------------------------------- |--------------|
- *  | V99 | WARNING    | Student must NOT be reported in Grade 8 or 9                |V92           |
+ *  | V99 | WARNING    | Student must be reported in Grade 8 or 9                   |V92           |
  *                     with FTE>0 in any other districts in previous
- *                     collection this school year.
+ *                     collection this school year to receive funding.
  */
 @Component
 @Slf4j
-@Order(926)
+@Order(924)
 public class SummerStudentReportedInOtherDistrictRule implements ValidationBaseRule {
     private final ValidationRulesService validationRulesService;
 
@@ -50,9 +50,9 @@ public class SummerStudentReportedInOtherDistrictRule implements ValidationBaseR
 
         validationRulesService.setupPENMatchAndEllAndGraduateValues(studentRuleData);
         if(studentRuleData.getSdcSchoolCollectionStudentEntity().getAssignedStudentId() != null) {
-            var isStudentReportedInCurrentFiscal = validationRulesService.findStudentInHistoricalCollectionInOtherDistricts(studentRuleData);
+            var isStudentReportedInCurrentFiscal = validationRulesService.findStudentInCurrentFiscalInOtherDistrictsNotInGrade8Or9WithNonZeroFte(studentRuleData);
 
-            if (isStudentReportedInCurrentFiscal) {
+            if (!isStudentReportedInCurrentFiscal) {
                 errors.add(createValidationIssue(StudentValidationIssueSeverityCode.FUNDING_WARNING, StudentValidationFieldCode.ENROLLED_GRADE_CODE, StudentValidationIssueTypeCode.SUMMER_STUDENT_REPORTED_NOT_IN_DISTRICT_ERROR));
             }
         }

--- a/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/service/v1/ValidationRulesService.java
+++ b/api/src/main/java/ca/bc/gov/educ/studentdatacollection/api/service/v1/ValidationRulesService.java
@@ -191,9 +191,9 @@ public class ValidationRulesService {
         return sdcSchoolStudentRepository.findStudentInCurrentFiscalInAllDistrict(studentRuleData.getSdcSchoolCollectionStudentEntity().getAssignedStudentId(), noOfCollectionsForLookup);
     }
 
-    public boolean findStudentInHistoricalCollectionInOtherDistricts(StudentRuleData studentRuleData) {
+    public boolean findStudentInCurrentFiscalInOtherDistrictsNotInGrade8Or9WithNonZeroFte(StudentRuleData studentRuleData) {
         String noOfCollectionsForLookup = "3";
-        List<SdcSchoolCollectionStudentEntity> entity = sdcSchoolStudentRepository.findStudentInCurrentFiscalInOtherDistricts(UUID.fromString(studentRuleData.getSchool().getDistrictId()), studentRuleData.getSdcSchoolCollectionStudentEntity().getAssignedStudentId(), noOfCollectionsForLookup);
+        List<SdcSchoolCollectionStudentEntity> entity = sdcSchoolStudentRepository.findStudentInCurrentFiscalInOtherDistrictsNotInGrade8Or9WithNonZeroFte(UUID.fromString(studentRuleData.getSchool().getDistrictId()), studentRuleData.getSdcSchoolCollectionStudentEntity().getAssignedStudentId(), noOfCollectionsForLookup);
         return !entity.isEmpty();
     }
 }

--- a/api/src/test/java/ca/bc/gov/educ/studentdatacollection/api/calculator/FteCalculatorUtilsTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/studentdatacollection/api/calculator/FteCalculatorUtilsTest.java
@@ -1663,7 +1663,7 @@ class FteCalculatorUtilsTest {
         school.setDistrictId(UUID.randomUUID().toString());
         studentRuleData.setSchool(school);
 
-        when(sdcSchoolCollectionStudentRepository.findStudentInCurrentFiscalInOtherDistricts(any(UUID.class), any(UUID.class), any(String.class))).thenReturn(Collections.singletonList(previousStudentEntity));
+        when(sdcSchoolCollectionStudentRepository.findStudentInCurrentFiscalInOtherDistrictsNotInGrade8Or9WithNonZeroFte(any(UUID.class), any(UUID.class), any(String.class))).thenReturn(Collections.singletonList(previousStudentEntity));
 
         studentRuleData.setSdcSchoolCollectionStudentEntity(student);
 
@@ -1690,7 +1690,7 @@ class FteCalculatorUtilsTest {
         school.setDistrictId(UUID.randomUUID().toString());
         studentRuleData.setSchool(school);
 
-        when(sdcSchoolCollectionStudentRepository.findStudentInCurrentFiscalInOtherDistricts(any(UUID.class), any(UUID.class), any(String.class))).thenReturn(Collections.singletonList(previousStudentEntity));
+        when(sdcSchoolCollectionStudentRepository.findStudentInCurrentFiscalInOtherDistrictsNotInGrade8Or9WithNonZeroFte(any(UUID.class), any(UUID.class), any(String.class))).thenReturn(Collections.singletonList(previousStudentEntity));
 
         studentRuleData.setSdcSchoolCollectionStudentEntity(student);
 
@@ -1698,7 +1698,7 @@ class FteCalculatorUtilsTest {
         var result = fteCalculatorUtils.reportedInOtherDistrictsInPreviousCollectionThisSchoolYearInGrade8Or9WithNonZeroFte(studentRuleData);
 
         // Then
-        assertFalse(result);
+        assertTrue(result);
     }
 
     @Test
@@ -1717,7 +1717,7 @@ class FteCalculatorUtilsTest {
         school.setDistrictId(UUID.randomUUID().toString());
         studentRuleData.setSchool(school);
 
-        when(sdcSchoolCollectionStudentRepository.findStudentInCurrentFiscalInOtherDistricts(any(UUID.class), any(UUID.class), any(String.class)))
+        when(sdcSchoolCollectionStudentRepository.findStudentInCurrentFiscalInOtherDistrictsNotInGrade8Or9WithNonZeroFte(any(UUID.class), any(UUID.class), any(String.class)))
                 .thenReturn(Collections.singletonList(previousStudentEntity));
 
         studentRuleData.setSdcSchoolCollectionStudentEntity(student);
@@ -1726,7 +1726,7 @@ class FteCalculatorUtilsTest {
         var result = fteCalculatorUtils.reportedInOtherDistrictsInPreviousCollectionThisSchoolYearInGrade8Or9WithNonZeroFte(studentRuleData);
 
         // Then
-        assertFalse(result);
+        assertTrue(result);
     }
 
     @Test
@@ -1740,7 +1740,7 @@ class FteCalculatorUtilsTest {
         school.setDistrictId(UUID.randomUUID().toString());
         studentRuleData.setSchool(school);
 
-        when(sdcSchoolCollectionStudentRepository.findStudentInCurrentFiscalInOtherDistricts(any(UUID.class), any(UUID.class), any(String.class))).thenReturn(Collections.emptyList());
+        when(sdcSchoolCollectionStudentRepository.findStudentInCurrentFiscalInOtherDistrictsNotInGrade8Or9WithNonZeroFte(any(UUID.class), any(UUID.class), any(String.class))).thenReturn(Collections.emptyList());
 
         studentRuleData.setSdcSchoolCollectionStudentEntity(student);
 

--- a/api/src/test/java/ca/bc/gov/educ/studentdatacollection/api/rules/SummerRulesProcessorTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/studentdatacollection/api/rules/SummerRulesProcessorTest.java
@@ -528,7 +528,7 @@ class SummerRulesProcessorTest extends BaseStudentDataCollectionAPITest {
         UUID schoolId = UUID.fromString(school.getSchoolId());
         LocalDateTime currentCloseDate = LocalDateTime.now().plusDays(2);
 
-        createHistoricalCollectionWithStudentInGrade07(CollectionTypeCodes.MAY.getTypeCode(), LocalDateTime.of(mayCloseDate, LocalTime.MIDNIGHT), assignedStudentID);
+        createHistoricalCollectionWithStudent(CollectionTypeCodes.MAY.getTypeCode(), LocalDateTime.of(mayCloseDate, LocalTime.MIDNIGHT), assignedStudentID, UUID.fromString(district.getDistrictId()), schoolId);
 
         var collection = createMockCollectionEntity();
         collection.setCollectionTypeCode(JULY.getTypeCode());
@@ -616,7 +616,7 @@ class SummerRulesProcessorTest extends BaseStudentDataCollectionAPITest {
         UUID schoolId = UUID.fromString(school.getSchoolId());
         LocalDateTime currentCloseDate = LocalDateTime.now().plusDays(2);
         doReturn(Optional.of(school)).when(restUtils).getSchoolBySchoolID(schoolId.toString());
-        createHistoricalCollectionWithStudentInGrade07(CollectionTypeCodes.MAY.getTypeCode(), LocalDateTime.of(mayCloseDate, LocalTime.MIDNIGHT), assignedStudentID);
+        createHistoricalCollectionWithStudent(CollectionTypeCodes.MAY.getTypeCode(), LocalDateTime.of(mayCloseDate, LocalTime.MIDNIGHT), assignedStudentID, UUID.fromString(district.getDistrictId()), schoolId);
         var collection = createMockCollectionEntity();
         collection.setCollectionTypeCode(JULY.getTypeCode());
         collection.setCloseDate(currentCloseDate);
@@ -704,7 +704,7 @@ class SummerRulesProcessorTest extends BaseStudentDataCollectionAPITest {
         UUID schoolId = UUID.fromString(school.getSchoolId());
         LocalDateTime currentCloseDate = LocalDateTime.now().plusDays(2);
         doReturn(Optional.of(school)).when(restUtils).getSchoolBySchoolID(schoolId.toString());
-        createHistoricalCollectionWithStudent(CollectionTypeCodes.MAY.getTypeCode(), LocalDateTime.of(mayCloseDate, LocalTime.MIDNIGHT), assignedStudentID, UUID.fromString(district.getDistrictId()), schoolId);
+        createHistoricalCollectionWithStudentInGrade07(CollectionTypeCodes.MAY.getTypeCode(), LocalDateTime.of(mayCloseDate, LocalTime.MIDNIGHT), assignedStudentID);
 
         var collection = createMockCollectionEntity();
         collection.setCollectionTypeCode(JULY.getTypeCode());
@@ -792,7 +792,7 @@ class SummerRulesProcessorTest extends BaseStudentDataCollectionAPITest {
         UUID schoolId = UUID.fromString(school.getSchoolId());
         LocalDateTime currentCloseDate = LocalDateTime.now().plusDays(2);
         doReturn(Optional.of(school)).when(restUtils).getSchoolBySchoolID(schoolId.toString());
-        createHistoricalCollectionWithStudent(CollectionTypeCodes.SEPTEMBER.getTypeCode(), LocalDateTime.of(mayCloseDate, LocalTime.MIDNIGHT), assignedStudentID, UUID.fromString(district.getDistrictId()), schoolId);
+        createHistoricalCollectionWithStudentInGrade07(CollectionTypeCodes.SEPTEMBER.getTypeCode(), LocalDateTime.of(mayCloseDate, LocalTime.MIDNIGHT), assignedStudentID);
 
         var collection = createMockCollectionEntity();
         collection.setCollectionTypeCode(JULY.getTypeCode());
@@ -835,6 +835,9 @@ class SummerRulesProcessorTest extends BaseStudentDataCollectionAPITest {
         UUID schoolId = UUID.fromString(school.getSchoolId());
         LocalDateTime currentCloseDate = LocalDateTime.now().plusDays(2);
         doReturn(Optional.of(school)).when(restUtils).getSchoolBySchoolID(schoolId.toString());
+        LocalDate mayCloseDate = LocalDate.parse(LocalDate.now().getYear() + "-05-30");
+
+        createHistoricalCollectionWithStudentInGrade07(CollectionTypeCodes.MAY.getTypeCode(), LocalDateTime.of(mayCloseDate, LocalTime.MIDNIGHT), assignedStudentID);
 
         var collection = createMockCollectionEntity();
         collection.setCollectionTypeCode(CollectionTypeCodes.JULY.getTypeCode());
@@ -881,6 +884,9 @@ class SummerRulesProcessorTest extends BaseStudentDataCollectionAPITest {
         UUID schoolId = UUID.fromString(school.getSchoolId());
         LocalDateTime currentCloseDate = LocalDateTime.now().plusDays(2);
         doReturn(Optional.of(school)).when(restUtils).getSchoolBySchoolID(schoolId.toString());
+        LocalDate mayCloseDate = LocalDate.parse(LocalDate.now().getYear() + "-05-30");
+
+        createHistoricalCollectionWithStudentInGrade07(CollectionTypeCodes.MAY.getTypeCode(), LocalDateTime.of(mayCloseDate, LocalTime.MIDNIGHT), assignedStudentID);
 
         var collection = createMockCollectionEntity();
         collection.setCollectionTypeCode(JULY.getTypeCode());


### PR DESCRIPTION
the code was throwing the error if the student was reported in grade 8 or 9 with fte>=0 in any other district for the fiscal

really we want the opposite, if the student was not reported in grade 8 or 9 with fte>=0 in any other district for the fiscal we want the error

i.e., they are not eligible for funding if they were not previously reported with these things (grade 8/9, other district, fte>=0, same fiscal)




